### PR TITLE
Issue 18: Animation from interactions

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1441,7 +1441,7 @@
 					<p>translation of one language, generally a spoken language, into a <a>sign language</a></p>
 					<p>True sign languages are independent languages that are unrelated to the spoken language(s) of the same country or region.</p>
 				</dd>
-        <dt><dfn>Significant animation</dfn></dt>
+        <dt><dfn data-lt="Significant animations">Significant animation</dfn></dt>
 		  <dd>
 					<p>animation which continues for more than 3 seconds, or is synchronized with a user action (e.g. parallax scrolling effects), and affects more than 1/3 of the viewport.</p>
 				</dd>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -596,6 +596,14 @@
 					<p>When an authenticated session expires, the user can continue the activity without loss of data after re-authenticating.</p>
 				</section>
 			</section>
+      
+      <section class="sc">
+					<h4>Animation from interactions</h4>
+					<p class="conformance-level">A</p>
+					<p class="change">Unchanged</p>
+					<p>For significant animation triggered by a user action that is not an essential part of the action, there is a mechanism for the user to pause, stop or hide the animation whilst still performing the same action.</p>
+				</section>
+			</section>
 
 			<section class="guideline">
 				<h3>@@</h3>
@@ -1432,6 +1440,10 @@
 				<dd>
 					<p>translation of one language, generally a spoken language, into a <a>sign language</a></p>
 					<p>True sign languages are independent languages that are unrelated to the spoken language(s) of the same country or region.</p>
+				</dd>
+        <dt><dfn>Significant animation</dfn></dt>
+				<dd>
+					<p>animation which continues for more than 3 seconds, or is synchronized with a user action, and affects more than 1/3 of the viewport.</p>
 				</dd>
 				<dt><dfn>specific sensory experience</dfn></dt>
 				<dd>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -600,8 +600,8 @@
       <section class="sc">
 					<h4>Animation from interactions</h4>
 					<p class="conformance-level">A</p>
-					<p class="change">Unchanged</p>
-					<p>For significant animation triggered by a user action that is not an essential part of the action, there is a mechanism for the user to pause, stop or hide the animation whilst still performing the same action.</p>
+					<p class="change">New</p>
+					<p>For significant animations triggered by a user action that is not an essential part of the action, there is a mechanism for the user to pause, stop or hide the animations while still performing the same action.</p>
 				</section>
 			</section>
 
@@ -1441,9 +1441,9 @@
 					<p>translation of one language, generally a spoken language, into a <a>sign language</a></p>
 					<p>True sign languages are independent languages that are unrelated to the spoken language(s) of the same country or region.</p>
 				</dd>
-        <dt><dfn>Significant animation</dfn></dt>
+        <dt><dfn><a>Significant animation</a></dfn></dt>
 				<dd>
-					<p>animation which continues for more than 3 seconds, or is synchronized with a user action, and affects more than 1/3 of the viewport.</p>
+					<p>animation which continues for more than 3 seconds, or is synchronized with a user action (e.g. parallax scrolling effects), and affects more than 1/3 of the viewport.</p>
 				</dd>
 				<dt><dfn>specific sensory experience</dfn></dt>
 				<dd>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -601,7 +601,7 @@
 					<h4>Animation from interactions</h4>
 					<p class="conformance-level">A</p>
 					<p class="change">New</p>
-					<p>For significant animations triggered by a user action that is not an essential part of the action, there is a mechanism for the user to pause, stop or hide the animations while still performing the same action.</p>
+					<p>For <a>significant animations</a> triggered by a user action that is not an essential part of the action, there is a mechanism for the user to pause, stop or hide the animations while still performing the same action.</p>
 				</section>
 			</section>
 
@@ -1441,8 +1441,8 @@
 					<p>translation of one language, generally a spoken language, into a <a>sign language</a></p>
 					<p>True sign languages are independent languages that are unrelated to the spoken language(s) of the same country or region.</p>
 				</dd>
-        <dt><dfn><a>Significant animation</a></dfn></dt>
-				<dd>
+        <dt><dfn>Significant animation</dfn></dt>
+		  <dd>
 					<p>animation which continues for more than 3 seconds, or is synchronized with a user action (e.g. parallax scrolling effects), and affects more than 1/3 of the viewport.</p>
 				</dd>
 				<dt><dfn>specific sensory experience</dfn></dt>


### PR DESCRIPTION
## Adding SC text and definition

Latest text and info:

### SC Shortname

Animation from interactions

**Note**: The original issue was [Animation from interactions](https://github.com/w3c/wcag21/issues/18).

### SC Text

For significant animations triggered by a user action that is not an essential part of the action, there is a mechanism for the user to pause, stop or hide the animations while still performing the same action.

### Suggestion for Priority Level (A/AA/AAA)

Level A.

It extends "Pause, stop hide" (Level A) to cover another scenario.

### Related Glossary additions or changes

[Essential](https://www.w3.org/TR/WCAG20/#essentialdef) (already defined)

Significant animation: animation which continues for more than 3 seconds, or is synchronized with a user action (e.g. parallax scrolling effects), and affects more than 1/3 of the viewport.

### What Principle and Guideline the SC falls within.

Principle 2, Guideline 2.2.

It applies the same principle as "2.2.2 Pause, Stop, Hide", which is under "Guideline 2.2 Enough Time".

### Description

"SC 2.2.2 Pause, Stop, Hide" applies when the web page initiates animation, "Animation from interactions" should apply when an interaction of the user initiates animation unexpectedly.

When users take an action not normally associated with animation but some animation is triggered, it can cause distraction or nausea. For example, if scrolling a page causes elements to move (other than the normal movement associated with scrolling) it can trigger vestibular disorders, causing nausea and headaches. A good [overview of vestibular disorders on A List Apart](http://alistapart.com/article/designing-safer-web-animation-for-motion-sensitivity) from a web design point of view, and an [official organisation](http://vestibular.org/). 

If backgrounds move at a different rate to foregrounds (often termed "parallax scrolling") that can be a trigger, as are foreground animations of items moving in or out of view, rotating etc. 

This [interview goes through examples](https://www.youtube.com/watch?v=QhnIZh0xwk0). For more information please consult [Evidence](https://www.w3.org/WAI/GL/wiki/Animation_caused_by_user_interaction#Evidence) and [Examples](https://www.w3.org/WAI/GL/wiki/Animation_caused_by_user_interaction#Examples) on the Wiki.

A webpage needs to either not use these types of animation, or provide mechanism for the user to turn them off.

### Benefits

The people who benefit from this SC include those who benefit from "Pause, Stop, Hide", as it adds another situation where animation can be triggered. People with vestibular disorders are added as beneficiaries as they cannot always anticipate when animation happens, and are negatively affected if there is no warning or way of turning off the animations.

**Note**: The impact can be quite severe, triggering nausea, migraine, and potentially bed rest to recover.


### Testability

For each example of animation on a page/view check if:

1.  The animation is triggered by a user-action, and
2.  the animation includes movement that is not essential to the action, and
3.  the animation continues for more than 3 seconds, or is synchronized with a user action, and affects more than 1/3 of the viewport
4.  there is no way of using the webpage without triggering the animation.

If all are true then it fails.

### Techniques

- G186: Using a control in the Web page that stops moving, blinking, or auto-updating content
-  (Future) Using media query preferences to prevent animation [CSS WG bug on reduce-motion media query](https://github.com/w3c/csswg-drafts/issues/442).

### Related Information

#### Articles

-  [Designing Safer Web Animation For Motion Sensitivity](http://alistapart.com/article/designing-safer-web-animation-for-motion-sensitivity)  - Val Head
-  [Vestibular Disorders and Accessible Animation Video Interview with ](https://www.youtube.com/watch?v=QhnIZh0xwk0) - Rachel Nabors
-  [An Introduction to the Reduced Motion Media Query]( https://css-tricks.com/introduction-reduced-motion-media-query/ ) - Eric Bailey 

#### <span id="Surveys">Surveys</span>
*  [Results of Questionnaire SC review February 7 2017](https://www.w3.org/2002/09/wbs/35422/SC_20170207/results#xq4)