### PR TITLE
Adding issue #9 Graphics Contrast

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -496,7 +496,7 @@
                             <p>The visual presentation of graphical objects that are essential for understanding the content or functionality have a contrast ratio of at least 4.5:1 against the adjacent color(s), except for the following:</p>
                             <dl>
                                 <dt>Thicker</dt>
-                                <dd>The minimum width and height of the graphical object is at least 3 CSS pixels the graphic has a contrast ratio of at least 3:1.</dd>
+                                <dd>For graphical objects with a minimum width and height of at least 3 CSS pixels, the graphic has a contrast ratio of at least 3:1.</dd>
                                 <dt>Sensory</dt>
                                 <dd>Non-text content that is primarily intended to create a visual sensory experience has no minimum contrast requirement;</dd>
                                 <dt>Logotypes</dt>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -501,6 +501,8 @@
                                 <dd>Non-text content that is primarily intended to create a visual sensory experience has no minimum contrast requirement;</dd>
                                 <dt>Logotypes</dt>
                                 <dd>Graphics that are part of a logo or brand name have no minimum contrast requirement.</dd>
+                                <dt>Essential</dt>
+                                <dd>A particular presentation of the graphical is essential to the information being conveyed.</dd>
                             </dl>
                         </section>
 

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -488,6 +488,22 @@
 					<p class="change">Unchanged</p>
 					<p><a>Images of text</a> are only used for <a>pure decoration</a> or where a particular presentation of <a>text</a> is <a>essential</a> to the information being conveyed.</p>
 				</section>
+
+                        <section class="sc">
+                            <h4>Graphics Contrast</h4>
+                            <p class="conformance-level">AA</p>
+                            <p class="change">New</p>
+                            <p>The visual presentation of graphical objects that are essential for understanding the content or functionality have a contrast ratio of at least 4.5:1 against the adjacent color(s), except for the following:</p>
+                            <dl>
+                                <dt>Thicker</dt>
+                                <dd>The minimum width and height of the graphical object is at least 3 CSS pixels the graphic has a contrast ratio of at least 3:1.</dd>
+                                <dt>Sensory</dt>
+                                <dd>Non-text content that is primarily intended to create a visual sensory experience has no minimum contrast requirement;</dd>
+                                <dt>Logotypes</dt>
+                                <dd>Graphics that are part of a logo or brand name have no minimum contrast requirement.</dd>
+                            </dl>
+                        </section>
+
 			</section>
 		</section>
 
@@ -1157,6 +1173,10 @@
 				<dd>
 					<p>any sequence where words and paragraphs are presented in an order that does not change the meaning of the content</p>
 				</dd>
+                        <dt><dfn>CSS pixels</dfn></dt>
+                        <dd>
+                              <p>The reference size that browsers use to calculate the how large text and elements appear when presented on screen. The value of a CSS pixel is set as closely as possible to the <a href="https://www.w3.org/TR/css3-values/#reference-pixel">reference pixel</a>, which takes into account the assumed viewing distance. For example, 1px on a TV display at 3.5m away is much larger than 1px on a phone 30cm feet away. A high resolution display would include more physical (device) pixels for each CSS pixel used in the browser's calculations for text and layout size.</p>
+                        </dd>
 				<dt><dfn>emergency</dfn></dt>
 				<dd>
 					<p>a sudden, unexpected situation or occurrence that requires immediate action to preserve health, safety, or property</p>
@@ -1198,6 +1218,10 @@
 					<p>The current working definition in the field for <strong>"pair of opposing transitions involving a saturated red"</strong> is where, for either or both states involved in each transition, R/(R+ G + B) &gt;= 0.8, and the change in the value of (R-G-B)x320 is &gt; 20 (negative values of (R-G-B)x320 are set to zero) for both transitions. R, G, B values range from 0-1 as specified in “relative luminance” definition. [[HARDING-BINNIE]]</p>
 					<p>Tools are available that will carry out analysis from video screen capture. However, no tool is necessary to evaluate for this condition if flashing is less than or equal to 3 flashes in any one second. Content automatically passes (see #1 and #2 above).</p>
 				</dd>
+                        <dt><dfn>graphical object</dfn></dt>
+                        <dd>
+                              <p>A graphic or section of a graphic that represents a distinct object or sub-component with semantic meaning. It may be a component of a larger structured graphic such as a chart or map. There is a related concept in the <a href="https://www.w3.org/TR/graphics-aria-1.0/#graphics-object">ARIA graphics module</a> for graphics with a document structure but this applies to bitmap and vector graphics, or distinct visual elements within them.</p>
+                        </dd>
 				<dt><dfn>human language</dfn></dt>
 				<dd>
 					<p>language that is spoken, written or signed (through visual or tactile means) to communicate with humans</p>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1175,7 +1175,7 @@
 				</dd>
                         <dt><dfn>CSS pixels</dfn></dt>
                         <dd>
-                              <p>The reference size that browsers use to calculate the how large text and elements appear when presented on screen. The value of a CSS pixel is set as closely as possible to the <a href="https://www.w3.org/TR/css3-values/#reference-pixel">reference pixel</a>, which takes into account the assumed viewing distance. For example, 1px on a TV display at 3.5m away is much larger than 1px on a phone 30cm feet away. A high resolution display would include more physical (device) pixels for each CSS pixel used in the browser's calculations for text and layout size.</p>
+                              <p>A CSS pixel is the canonical unit of measure for all lengths and measurements in CSS. This unit is density-independent, and distinct from actual hardware pixels present in a display. User agents and operating systems should ensure that a CSS pixel is set as closely as possible to the <a href="https://www.w3.org/TR/css3-values/#reference-pixel">reference pixel</a>, which takes into account the physical dimensions of the display and the assumed viewing distance (factors which cannot be determined by content authors).</p>
                         </dd>
 				<dt><dfn>emergency</dfn></dt>
 				<dd>


### PR DESCRIPTION
Adding the graphics contrast SC #9 plus two glossary terms for graphical object, and CSS pixel.

Latest text:

## Graphics Contrast

The visual presentation of graphical objects that are essential for understanding the content or functionality have a contrast ratio of at least 4.5:1 against the adjacent color(s), except for the following:

- Thicker: For graphical objects with a minimum width and height of at least 3 CSS pixels, the graphic has a contrast ratio of at least 3:1.
- Sensory: Non-text content that is primarily intended to create a visual sensory experience has no minimum contrast requirement;
- Logotypes: Graphics that are part of a logo or brand name have no minimum contrast requirement.
- Essential: A particular presentation of the graphical is essential to the information being conveyed.

## Glossary items

### graphical object

A graphic or section of a graphic that represents a distinct object or sub-component with semantic meaning. It may be a component of a larger structured graphic such as a chart or map. There is a related concept in the <a href="https://www.w3.org/TR/graphics-aria-1.0/#graphics-object">ARIA graphics module</a> for graphics with a document structure but this applies to bitmap and vector graphics, or distinct visual elements within them.

### CSS Pixel
A CSS pixel is the canonical unit of measure for all lengths and measurements in CSS. This unit is density-independent, and distinct from actual hardware pixels present in a display. User agents and operating systems should ensure that a CSS pixel is set as closely as possible to the reference pixel, which takes into account the physical dimensions of the display and the assumed viewing distance (factors which cannot be determined by content authors).