### PR TITLE
Accidental activation

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -778,7 +778,7 @@
 				
 </section>
       	<section class="sc">
-					<h4>Accidental Activation</h4>
+					<h4>Change on Request</h4>
 					<p class="conformance-level">AAA</p>
 					<p class="change">Unchanged</p>
 					<p><a>Changes of context</a> are initiated only by user request or a <a>mechanism</a> is available to turn off such changes.</p>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -775,15 +775,31 @@
 					<p>Components that have the <a>same functionality</a> within a <a>set of Web pages</a> are identified consistently.</p>
 				</section>
 
-				<section class="sc">
-					<h4>Change on Request</h4>
+				
+</section>
+      	<section class="sc">
+					<h4>Accidental Activation</h4>
 					<p class="conformance-level">AAA</p>
 					<p class="change">Unchanged</p>
 					<p><a>Changes of context</a> are initiated only by user request or a <a>mechanism</a> is available to turn off such changes.</p>
 				</section>
+      
+      <section class="sc">
+					<h4>Accidental Activation</h4>
+					<p class="conformance-level">A</p>
+					<p class="change">Unchanged</p>
+          <p>For single pointer activation, at least one of the following is true:</p>
+<ul><li>Activation is on the up-event, either explicitly or implicitly as a platform's generic activation/click event;</li>
+<li>A mechanism is available that allows the user to choose the up-event as an option;</li>
+<li>Confirmation is provided, which can dismiss activation;</li>
+<li>Activation is reversible;</li>
+<li>Timing of activation is essential and waiting for the up-event would invalidate the activity.</li></ul>
+<p>Note: This success criteria applies when platform assistive technology (e.g. screen reader) that remaps touch gestures is not turned on - see proposed SC Touch with Assistive Technology.</p>
+  </section>
 			</section>
 
 			<section class="guideline">
+        <section class="sc">
 				<h3>Input Assistance</h3>
 				<p>Help users avoid and correct mistakes.</p>
 

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -775,8 +775,6 @@
 					<p>Components that have the <a>same functionality</a> within a <a>set of Web pages</a> are identified consistently.</p>
 				</section>
 
-				
-</section>
       	<section class="sc">
 					<h4>Change on Request</h4>
 					<p class="conformance-level">AAA</p>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -785,15 +785,16 @@
       <section class="sc">
 					<h4>Accidental Activation</h4>
 					<p class="conformance-level">A</p>
-					<p class="change">Unchanged</p>
+					<p class="change">New</p>
           <p>For single pointer activation, at least one of the following is true:</p>
 <ul><li>Activation is on the up-event, either explicitly or implicitly as a platform's generic activation/click event;</li>
 <li>A mechanism is available that allows the user to choose the up-event as an option;</li>
 <li>Confirmation is provided, which can dismiss activation;</li>
 <li>Activation is reversible;</li>
 <li>Timing of activation is essential and waiting for the up-event would invalidate the activity.</li></ul>
-<p>Note: This success criteria applies when platform assistive technology (e.g. screen reader) that remaps touch gestures is not turned on - see proposed SC Touch with Assistive Technology.</p>
-  </section>
+<p class="note">This success criteria applies when platform assistive technology (e.g. screen reader) that remaps touch gestures is not turned on - see proposed SC Touch with Assistive Technology.</p>
+ 
+        </section>
 			</section>
 
 			<section class="guideline">
@@ -1487,7 +1488,11 @@
 					<p>An image of a chart is described in text in the paragraph after the chart. The short text alternative for the chart indicates that a description follows.</p>
 					<p>Refer to <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Text Alternatives</a> for more information.</p>
 				</dd>
-				<dt><dfn>used in an unusual or restricted way</dfn></dt>
+				<dt><dfn>Up-Event</dfn></dt>
+        <dd>The activation of a component when the trigger stimulus is released. On different platforms the "up-event" may be called different things, such as "touchend" or "mouseup".
+            Example: For touchscreen interaction, the event is triggered when a finger is lifted from the touchscreen at the end of a tap.</dd>
+        
+        <dt><dfn>used in an unusual or restricted way</dfn></dt>
 				<dd>
 					<p>words used in such a way that requires users to know exactly which definition to apply in order to understand the content correctly</p>
 					<p>The term "gig" means something different if it occurs in a discussion of music concerts than it does in article about computer hard drive space, but the appropriate definition can be determined from context. By contrast, the word "text" is used in a very specific way in WCAG 2.0, so a definition is supplied in the glossary.</p>


### PR DESCRIPTION
This is from issue #65 

# SC Text

For single pointer activation, at least one of the following is true:
- Activation is on the up-event, either explicitly or implicitly as a platform's generic activation/click event;
- A mechanism is available that allows the user to choose the up-event as an option;
- Confirmation is provided or another way to dismiss activation is provided once it has begun;
- Activation is reversible;
- Timing of activation is essential and waiting for the up-event would invalidate the activity.

Note: This success criteria applies when platform assistive technology (e.g. screen reader) that remaps touch gestures is not turned on - see proposed SC Touch with Assistive Technology.

# Suggestion for Priority Level (A/AA/AAA)

Level A

<h1>Related Glossary additions or changes</h1>
<p>Up-Event: The activation of a component when the trigger stimulus is released. On different platforms the "up-event" may be called different things, such as "touchend" or "mouseup".<br>
Example: For touchscreen interaction, the event is triggered when a finger is lifted from the touchscreen at the end of a tap.</p>
<p>Platform assistive technology that remaps touch gestures: Software that is integrated into the operating system, ships with the product, and/or is updated or installed via system updates. This software changes the characteristics of the touch interface when turned on. (e.g., a system screen reader may remap a right swipe gesture to move focus from item to item instead of it's default behaviour when the assistive technology is not on).</p>
<p>Single Pointer Activation: One point of contact with the screen (vs. multi-touch). A pointer can be any point of contact on the screen made by a mouse cursor, pen, touch (including multi-touch), or other pointing input device. This model makes it easier to write sites and applications that work well no matter what hardware the user has. For scenarios when device-specific handling is desired, this specification also defines properties for inspecting. <a href="http://www.w3.org/TR/pointerevents/">Pointer Events (REC)</a> <a href="https://w3c.github.io/pointerevents/">Pointer Events Level 2 (ED)</a>]</p>
<h1>What Principle and Guideline the SC falls within.</h1>
<p>New Proposed Guideline "Pointer Accessible"</p>
<p>Make it easier for users to operate pointer functionality.</p>
<p>Editorial Note for WCAG group: Pointer includes "Touch" in its definition</p>
<h1>Description</h1>
<p>People with various disabilities can inadvertently initiate touch or mouse events with unwanted results. Up-Event activation refers to the activation of a component when the trigger stimulus is released. For example, for touchscreen interaction the event would be triggered when a finger is lifted from the touchscreen at the end of a tap.There is a distinction between when someone touches a screen and when they remove their finger. On a mouse there is a difference between mouse down (initiating a click) and mouse up (releasing the finger). Authors can reduce the problem of users inadvertently triggering an action, by making activation on the up-event. This gives users the opportunity to move their finger or other pointer (e.g. mouse) away from the wrong target once they hit it. If touch down activation is necessary, there are several options:</p>
<ul>
<li>A confirmation alert allows the user to change their mind</li>
<li>An undo button or other mechanism allows the user to reverse the action.</li>
<li>A setting in preferences allows the user to choose whether activation happens on the down or up event.</li>
</ul>
<p>Generic platform activation/click events generally trigger on up and when they do, they are also allowed. For example, in the case of mouse interactions, the "click" event in JavaScript triggers on release of the primary mouse button, and is an example of an implicit up-event.</p>
<p>Examples of where timing of the activation is essential would be:</p>
<ul>
<li>An activity that would be invalid if activation waited for the up-event such as a piano program.</li>
<li>A program for shooting skeets where waiting for the "up" event would invalidate the activation.</li>
</ul>
<p>Long press activation and 3D touch can be used as long as one of the above listed alternatives is present, and there is another conforming way to provide the action performed by the control.</p>
<h2>Examples</h2>
<ul>
<li>For interface elements that have a single tap or long press as input, the corresponding event is triggered when the finger is lifted inside that element.</li>
<li>A phone dialling application has number keys that are activated on touch down. A user can undo an unwanted number by hitting the backspace button to delete a mistaken digit.</li>
</ul>
<h3> Examples of exceptions covered under the last bullet "Timing of activation is essential and waiting for the up-event would invalidate the activity." include:</h3>
<ul><li> a piano program where the notes need to play on the touch down. </li>
<li> An arcade game where the trigger of a gun is on the down event.</li>
<li> A drag and drop application where on the down event the element is "grabbed" in order to be moved.</li></ul>
<h1>Benefits</h1>
<ul>
<li>Makes it easier for all users to recover from hitting the wrong target.</li>
<li>Helps people with visual disabilities, cognitive limitations, and motor impairments by reducing the chance that a control will be accidentally activated or action will occur unexpectedly.</li>
<li>Individuals who are unable to detect changes of context are less likely to become disoriented while navigating a site.</li>
</ul>
<h2>Evidence</h2>
<ul>
<li><a href="http://www.mac-forums.com/ios-development/273383-touch-inside-fine-touch.html">Discussion forum showing up event is default</a></li>
<li><a href="https://developer.android.com/guide/topics/ui/ui-events.html">touch is activated on removing finger on Android by default</a></li>
<li><a href="http://trace.wisc.edu/docs/2010-phone-essentials/buttons.php">touch guidelines by trace</a></li>
<li>Jon A. was in touch with a research project which tested 30 users with physical dexterity disabilities. Results outstanding.</li>
</ul>
<p>NOTE:  There is feedback from the WCAG working group on this work. <a href="https://www.w3.org/2016/08/30-wai-wcag-minutes.html">Captured in minutes here</a> and in the <a href="https://www.w3.org/2002/09/wbs/35422/NewSC_initialthoughts/results">Survey remarks</a>.  This feedback has been incorporated into this SC.</p>
<h1>Testability</h1>
<p>The majority of the testing of this will be terminated after the first test.</p>
<p>Activation is on the up-event, either explicitly or implicitly as a platform's generic activation/click event;<br>
Test: Examine code for the Up-Event. This could be done with automated checking. OR activate the event with a pointer to ensure it activates on release rather than on contact.<br>
If that is not true, proceed to the next test.</p>
<p>A mechanism is available that allows the user to choose the up-event as an option;<br>
Test: Examine code for a mechanism that switches activation to the Up-Event. This test could be automated. Or functionally test it by examining for a mechanism that changes event activation to the up-Event.</p>
<p>Confirmation is provided, which can dismiss activation;<br>
Test: Examine code for a confirmation mechanism that allows the user not to proceed with the action. Or functionally test it by activating the control and looking for a confirmation dialogue that allows the user not to proceed with the action or to proceed with the action.</p>
<p>Activation is reversible;<br>
Test: Examine code Can be tested both functionally and by looking at the code for a control that reverses the activation.</p>
<p>Timing of activation is essential and waiting for the up-event would invalidate the activity.[edit]<br>
Test: Can be tested by considering whether activating as the user leaves the surface would invalidate the activity (up-event). AN example would be a piano program that needs the keys to lay as the user touches the key rather than when they leave the key. <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/time-limits-required-behaviors.html">WCAG 2.2.1</a></p>
<h1>Techniques</h1>
<ul>
<li>Activating a control using the up-Event in HTML, iOS and Android</li>
<li><a href="https://www.w3.org/WAI/GL/mobile-a11y-tf/wiki/M029">M029(wiki) Touch events are only triggered when touch is removed from a control</a></li>
<li><a href="http://w3c.github.io/Mobile-A11y-TF-Note/Techniques/FM001">FM001 Failure of SC 2.5.3 due to activating a button on initial touch location rather than the final touch location</a></li>
<li>Failure: Actions are only available through long press or 3D touch</li>
</ul>