### PR TITLE
Resize content (Issue 77)

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -493,7 +493,7 @@
                             <h4>Resize content</h4>
                             <p class="conformance-level">A</p>
                             <p class="change">New</p>
-                            <p>Content can be resized to 400% without loss of content or functionality and without requiring two-dimensional scrolling, except for parts of the content where fixed spatial layout is necessary to use or meaning.</p>
+                            <p>Content can be resized to 400% without loss of content or functionality, and without requiring two-dimensional scrolling except for parts of the content where fixed spatial layout is necessary to use or meaning.</p>
                         </section>
 
 			</section>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -488,6 +488,14 @@
 					<p class="change">Unchanged</p>
 					<p><a>Images of text</a> are only used for <a>pure decoration</a> or where a particular presentation of <a>text</a> is <a>essential</a> to the information being conveyed.</p>
 				</section>
+
+                        <section class="sc">
+                            <h4>Resize content</h4>
+                            <p class="conformance-level">A</p>
+                            <p class="change">New</p>
+                            <p>Content can be resized to 400% without loss of content, functionality or requiring two-dimensional scrolling, except for parts of the content where fixed spatial layout is essential to use or meaning.</p>
+                        </section>
+
 			</section>
 		</section>
 

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -493,7 +493,7 @@
                             <h4>Resize content</h4>
                             <p class="conformance-level">A</p>
                             <p class="change">New</p>
-                            <p>Content can be resized to 400% without loss of content, functionality or requiring two-dimensional scrolling, except for parts of the content where fixed spatial layout is essential to use or meaning.</p>
+                            <p>Content can be resized to 400% without loss of content or functionality and without requiring two-dimensional scrolling, except for parts of the content where fixed spatial layout is necessary to use or meaning.</p>
                         </section>
 
 			</section>


### PR DESCRIPTION
Adding Resize content from #77 

## Proposed SC text

Content can be resized to 400% without loss of content or functionality, and without requiring two-dimensional scrolling except for parts of the content where fixed spatial layout is necessary to use or meaning.

