### PR TITLE
NumericalContent-Issue32-Help

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -822,6 +822,12 @@
 					<p><a>Context-sensitive help</a> is available.</p>
 				</section>
 
+        <section class="sc">
+					<h4>Numerical Content</h4>
+					<p class="conformance-level">AA</p>
+					<p>Where an understanding of mathematics is not a primary requirement for using content, reinforce numbers with non-numerical values.</p>
+				</section>
+        
 				<section class="sc">
 					<h4>Error Prevention (All)</h4>
 					<p class="conformance-level">AAA</p>
@@ -1298,7 +1304,11 @@
 				<dd>
 					<p>navigated in the order defined for advancing focus (from one element to the next) using a <a>keyboard interface</a></p>
 				</dd>
-				<dt><dfn>non-text content</dfn></dt>
+        <dt><dfn>non-numerical value</dfn></dt>
+        <dd>
+          <p>a value that does not rely on understanding numerical concepts and is not expressed in numbers</p>
+        </dd>
+        <dt><dfn>non-text content</dfn></dt>
 				<dd>
 					<p>any content that is not a sequence of characters that can be <a>programmatically determined</a> or where the sequence is not expressing something in <a>human language</a></p>
 					<p>This includes <a>ASCII Art</a> (which is a pattern of characters), emoticons, leetspeak (which uses character substitution), and images representing text</p>


### PR DESCRIPTION
The original issue can be found at the following link: https://github.com/w3c/wcag21/issues/32
SC Numerical Content added under Context-Sensitive Help, within the Understandable Principle and under the Predictable Guideline
Glossary Term added:  non-numerical value