### PR TITLE
Added Accessibility Metadata, from dpub was Issue#82

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -488,6 +488,14 @@
 					<p class="change">Unchanged</p>
 					<p><a>Images of text</a> are only used for <a>pure decoration</a> or where a particular presentation of <a>text</a> is <a>essential</a> to the information being conveyed.</p>
 				</section>
+       
+        <section class="sc">
+					<h4>Accessibility Metadata</h4>
+					<p class="conformance-level">AAA</p>
+					<p class="change">New</p>
+					<p> Accessibility supported characteristics of the content can be programmatically discovered. At a minimum this is a machine readable description either on the page or referenced from the set of pages to which it applies. A human readable summary may also be provided.</p>
+				</section>
+        
 			</section>
 		</section>
 


### PR DESCRIPTION
This has been changed to a proposal for an amendment to the optional components of a conformance claim section Pull request #308 

This was issue #82 see further discussion there, and [over on Daisy](https://github.com/daisy/epub-revision-a11y/wiki/WCAG-Discovery-Metadata-Proposal)

This is a result of the joint call between WCAG members David, Katie, Wilco, and the epub team. starting with the SC wording, and the rest to completed soon. the discussion began on issue #16 

# Short Name
Accessibility Metadata
# SC Text

Accessibility supported characteristics of the content can be programmatically discovered. At a minimum this is a machine readable description either on the page or referenced from the set of pages to which it applies. A human readable summary may also be provided.

# Suggested Priority Level

Level AAA
# Related Glossary additions or changes
- Accessibility Metadata. 
(Definition to come)
- Openly-published vocabulary
(Definition to come)
- Machine readable description
(Definition to come)

# Principle: TBD<br />
The purpose of this Success Criterion is to ensure that users can find accessible content and identify specific characteristics about the content that might meet their needs. 

Metadata is especially important for publications, such as those that are packaged and distributed through third parties. The metadata allows users to discover more detailed information about publications without having to consume them first, as it can be processed by any search engine, whether in a proprietary bookstore or on the open web.

In a large and heterogeneous Web, helping users with accessibility needs locate accessible content is an important way to support the use of the Web by people with disabilities, and the same developers who are following WCAG guidelines to improve the accessibility of their Web content are likely to be the most motivated to apply accessibility metadata. (More here...)

# Specific Benefits of Success Criterion 1.5.1
- Users who are blind will know if content will work with their screen reader.
- Users who are deaf would know whether there are captions or sign language on videos.
- more....

## Justification and Evidence

Metadata was discussed in [WCAG 2 ](https://www.w3.org/TR/UNDERSTANDING-WCAG20/appendixC.html)

With the emergence of digital publishing there is a great need for users to know about the ebook before they get it, so they won't be buying things that are inaccessible. It will help users who are blind choose a book without wasting time.   (More here...)

## Testability

This can be tested programmatically or functionally. In the code identify metatada elements.  (More here...)

### Related Resources

Resources are for information purposes only, no endorsement implied.
http://pending.schema.org/.
 http://pending.schema.org/accessMode
 http://pending.schema.org/accessModeSufficient
 http://pending.schema.org/accessibilitySummary

Schema.org currently contains a set of four properties under CreativeWork that allow the expression of metadata about the accessible characteristics of a web page: accessibilityFeature, accessibilityHazard, accessibilityAPI and accessibilityControl. An additional three properties are currently pending inclusion: (accessMode](https://schema.org/accessMode), accessModeSufficient and accessibilitySummary. These properties are primarily based on the IMS Global Access for All metadata standard, and the original set of properties were submitted by IMS.  (More here...)

            
<p>Schema.org currently contains a set of four properties under <a href="http://schema.org/CreativeWork">CreativeWork</a> that allow the expression of metadata about the accessible characteristics of a web page: <a href="https://schema.org/accessibilityFeature">accessibilityFeature</a>, <a href="https://schema.org/accessibilityHazard">accessibilityHazard</a>, <a href="https://schema.org/accessibilityAPI">accessibilityAPI</a> and <a href="https://schema.org/accessibilityControl">accessibilityControl</a>. An additional three properties are currently pending inclusion: (accessMode](<a href="https://schema.org/accessMode">https://schema.org/accessMode</a>), <a href="https://schema.org/accessModeSufficient">accessModeSufficient</a> and <a href="https://schema.org/accessibilitySummary">accessibilitySummary</a>. These properties are primarily based on the IMS Global <a href="https://www.imsglobal.org/activity/accessibility#afav3p0">Access for All metadata standard</a>, and the original set of properties were submitted by IMS.</p>
<p>schema.org, more information about them is available in the <a href="https://www.w3.org/wiki/WebSchemas/Accessibility">Web Schemas accessibility wiki</a>. The pending properties are documented in a <a href="https://github.com/daisy/epub-revision-a11y/wiki/ePub-3.1-Accessibility--Proposal-To-Schema.org">wiki</a>. More information about the use of these properties in EPUB is also available in the Discovery sections of the <a href="http://www.idpf.org/epub/a11y/#sec-discovery">accessibility specification</a> and <a href="http://www.idpf.org/epub/a11y/techniques/#sec-discovery">techniques</a>.</p>

  
## Techniques
-  (More here...)

### Notes for working group
