### PR TITLE
change foreground to #008400

### DIFF
--- a/guidelines/guidelines.css
+++ b/guidelines/guidelines.css
@@ -44,3 +44,7 @@ dd.new, dd.proposed {
 .sc dt:after {
 	content: ":";
 }
+div.note-title, div.ednote-title {
+	color: #008400;
+}
+


### PR DESCRIPTION
The green text on green background (for the Editor's Notes) is not meeting color contrast. It is only 2.37 to 1. foreground color: #22bb22, background color: #e9fbe9
As Michael's suggestion: I add a style in guidelines.css, change it to foreground #008400/ background #e9fbe9