### PR TITLE
Addressed Issue 325 and editorial changes

### DIFF
--- a/guidelines/sc/21/accessible-authentication.html
+++ b/guidelines/sc/21/accessible-authentication.html
@@ -6,11 +6,11 @@
 	<p class="ednote">Discussion of the issue is available in <a href="https://github.com/w3c/wcag21/issues/23">Issue 23</a>. To file comments on this proposal, please <a href="https://github.com/w3c/wcag21/issues/new">raise new issues</a> for each discrete comment in GitHub.
 	</p>
 	<p>Essential steps of an authentication process, which rely upon recalling or transcribing information, have one of the following:</p>
-  <ul><li>alternative essential steps, which do not rely upon recalling and transcribing information; or</li><li>
-	an authentication-credentials reset process, which does not rely upon recalling and transcribing information</li></ul>
-  <p>Exceptions:</p>
+  <ul><li>alternative essential steps, which do not rely upon recalling or transcribing information; or</li><li>
+	an authentication-credentials reset process, which does not rely upon recalling or transcribing information</li></ul>
+  <p>Except for when any of the folloing are true:</p>
   <ul>
-  <li>Authentication process involves basic identifying information to which the user has easy access, such as name, address, email address and identification or social security number.
+  <li>Authentication process involves basic identifying information to which the user has access, such as name, address, email address and identification or social security number.
   </li>
   <li>This is not achievable due to legal requirements.   
   </li>

--- a/guidelines/sc/21/accessible-authentication.html
+++ b/guidelines/sc/21/accessible-authentication.html
@@ -8,9 +8,9 @@
 	<p>Essential steps of an authentication process, which rely upon recalling or transcribing information, have one of the following:</p>
   <ul><li>alternative essential steps, which do not rely upon recalling or transcribing information; or</li><li>
 	an authentication-credentials reset process, which does not rely upon recalling or transcribing information</li></ul>
-  <p>Except for when any of the folloing are true:</p>
+  <p>Except for when any of the following are true:</p>
   <ul>
-  <li>Authentication process involves basic identifying information to which the user has access, such as name, address, email address and identification or social security number.
+  <li>Authentication process involves basic personal identifying information to which the user has access, such as name, address, email address and identification or social security number.
   </li>
   <li>This is not achievable due to legal requirements.   
   </li>


### PR DESCRIPTION
Put in OR instead of AND for bullets to match the leading sentence. Updated the exception language to be more in alignment with current SC style. Removed the word EASY as per issue #375