### PR TITLE
Move Accidental Activation to Pointer Accessible guideline

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -239,6 +239,8 @@
 
                 <section data-include="sc/21/pointer-gestures.html" data-include-replace="true"></section>
 
+                <section data-include="sc/21/accidental-activation.html" data-include-replace="true"></section>
+
                 <section data-include="sc/21/concurrent-input-mechanisms.html" data-include-replace="true"></section>
 
                 <section data-include="sc/21/target-size.html" data-include-replace="true"></section>
@@ -295,8 +297,6 @@
                 <section data-include="sc/20/consistent-identification.html" data-include-replace="true"></section>
 
                 <section data-include="sc/20/change-on-request.html" data-include-replace="true"></section>
-
-                <section data-include="sc/21/accidental-activation.html" data-include-replace="true"></section>
 
                 <section data-include="sc/21/change-of-content.html" data-include-replace="true"></section>
                 

--- a/understanding/index.html
+++ b/understanding/index.html
@@ -238,6 +238,8 @@
 							<ul class="sc">
 								<li><a href="21/pointer-gestures.html">Pointer Gestures</a></li>
 								
+								<li><a href="21/accidental-activation.html">Accidental Activation</a></li>
+								
 								<li><a href="21/concurrent-input-mechanisms.html">Concurrent Input Mechanisms</a></li>
 
 								<li><a href="21/target-size.html">Target Size</a></li>
@@ -291,8 +293,6 @@
 								<!-- <li><a href="20/consistent-identification.html">Consistent Identification</a></li> -->
 	
 								<!-- <li><a href="20/change-on-request.html">Change on Request</a></li> -->
-	
-								<li><a href="21/accidental-activation.html">Accidental Activation</a></li>
 	
 								<li><a href="21/change-of-content.html">Change of Content</a></li>
 	


### PR DESCRIPTION
Closes #379 by moving Accidental Activation criterion to Pointer Accessible guideline per [working group decision](https://lists.w3.org/Archives/Public/w3c-wai-gl/2017JulSep/1169.html).