### PR TITLE
Add images of text to scope of SC Label in Name

### DIFF
--- a/guidelines/sc/21/label-in-name.html
+++ b/guidelines/sc/21/label-in-name.html
@@ -5,7 +5,7 @@
 	<p class="ednote">Discussion of the issue is available in <a href="https://github.com/w3c/wcag21/issues/68">Issue 68</a>. To file comments on this proposal, please <a href="https://github.com/w3c/wcag21/issues/new">raise new issues</a> for each discrete comment in GitHub.
 	</p>
 	
-  <p>For active <a>user interface components</a> with <a>labels</a> that include <a>text</a> or <a>images of text</a>, the <a>name</a> includes the text of the label.</p>
+  <p>For <a>user interface components</a> with <a>labels</a> that include <a>text</a> or <a>images of text</a>, the <a>name</a> contains the text presented.</p>
   
   <p class="note">A best practice is to have  the text of the label at the start of the name.</p>
 	

--- a/guidelines/sc/21/label-in-name.html
+++ b/guidelines/sc/21/label-in-name.html
@@ -5,7 +5,7 @@
 	<p class="ednote">Discussion of the issue is available in <a href="https://github.com/w3c/wcag21/issues/68">Issue 68</a>. To file comments on this proposal, please <a href="https://github.com/w3c/wcag21/issues/new">raise new issues</a> for each discrete comment in GitHub.
 	</p>
 	
-  <p>For active <a>user interface components</a> with <a>labels</a> that include text, the <a>name</a> includes the text of the label.</p>
+  <p>For active <a>user interface components</a> with <a>labels</a> that include <a>text</a> or <a>images of text</a>, the <a>name</a> includes the text of the label.</p>
   
   <p class="note">A best practice is to have  the text of the label at the start of the name.</p>
 	


### PR DESCRIPTION
Clarifies that labels that include both text and images of text are in scope.  Closes #484.