### PR TITLE
Udated and simplified targef def.

### DIFF
--- a/guidelines/terms/21/target.html
+++ b/guidelines/terms/21/target.html
@@ -3,11 +3,8 @@
    					
    <p class="change">New</p>
    					
-   <p>region of the display that will accept a touch action</p>
-	<p>If a portion of a touch target that does not perform the same action or go to the same page is overlapped by another touch target such that it cannot receive touch actions, then that portion is not considered a touch target for purposes of touch target measurements.
-   </p>
-
-     <p class="ednote">Proposed modification: Region of the display that will accept a pointer action. If a portion of a target that does not perform the same action or go to the same page is overlapped by another target such that it cannot receive pointer actions, then that portion is not considered part of the target for purposes of target measurements.
+     <p class="ednote">Proposed modification: Region of the display that will accept a pointer action.</p> 
+       <p>If some part of a target is covered by a different target so it cannot receive pointer actions, then that part of the target is excluded in target size measurements.</p>
    </p>
   
 </dd>

--- a/guidelines/terms/21/target.html
+++ b/guidelines/terms/21/target.html
@@ -3,8 +3,8 @@
    					
    <p class="change">New</p>
    					
-     <p class="ednote">Proposed modification: Region of the display that will accept a pointer action.</p> 
-       <p>If some part of a target is covered by a different target so it cannot receive pointer actions, then that part of the target is excluded in target size measurements.</p>
+     <p class="ednote">Proposed modification: Region of the display that will accept a pointer action, such as the interactive area of a user interface component.</p> 
+    <p>If two or more touch targets are overlapping, the overlapping area should not be included in the measurement of the target size, except when the overlapping targets perform the same action or open the same page.</p>
    </p>
   
 </dd>

--- a/guidelines/terms/21/target.html
+++ b/guidelines/terms/21/target.html
@@ -3,7 +3,7 @@
    					
    <p class="change">New</p>
    					
-     <p class="ednote">Proposed modification: Region of the display that will accept a pointer action, such as the interactive area of a user interface component.</p> 
+     <p>Region of the display that will accept a pointer action, such as the interactive area of a user interface component.</p> 
     <p>If two or more touch targets are overlapping, the overlapping area should not be included in the measurement of the target size, except when the overlapping targets perform the same action or open the same page.</p>
    </p>
   


### PR DESCRIPTION
The commenter in issue #671 found the definition of target hard to parse, and I agree.
I have changed 'touch action' to 'pointer action'.
I have also simplified the text. I don't think we need to spell out the outier case that the overlapping target goes to a different place / calls up a different action, it is just complicating things. One could add a note saying "For the purpose of target measurement, adjacent targets with identical action or link target can be considered one target".
  