### PR TITLE
Move Status Changes SC to Adaptable GL

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -112,6 +112,8 @@
 
                 <section data-include="sc/20/sensory-characteristics.html" data-include-replace="true"></section>
 
+                <section data-include="sc/21/status-changes.html" data-include-replace="true"></section>
+                
                 <section data-include="sc/21/identify-common-purpose.html" data-include-replace="true"></section>
               
                 <section data-include="sc/21/identify-purpose.html" data-include-replace="true"></section>
@@ -292,8 +294,6 @@
 
                 <section data-include="sc/20/change-on-request.html" data-include-replace="true"></section>
 
-                <section data-include="sc/21/status-changes.html" data-include-replace="true"></section>
-                
             </section>
 
             <section class="guideline">

--- a/understanding/index.html
+++ b/understanding/index.html
@@ -114,6 +114,8 @@
 	
 								<!-- <li><a href="20/sensory-characteristics.html">Sensory Characteristics</a></li> -->
 	
+								<li><a href="21/status-changes.html">Status Changes</a></li>
+	
 								<li><a href="21/identify-common-purpose.html">Identify Common Purpose</a></li>
 
 								<li><a href="21/contextual-information.html">Contextual Information</a></li>
@@ -291,8 +293,6 @@
 								<!-- <li><a href="20/consistent-identification.html">Consistent Identification</a></li> -->
 	
 								<!-- <li><a href="20/change-on-request.html">Change on Request</a></li> -->
-	
-								<li><a href="21/status-changes.html">Status Changes</a></li>
 	
 							</ul>
 						</li>


### PR DESCRIPTION
This pull moves the Status Changes SC from the Predictable GL (3.2) to the Adaptable GL (1.3).  This has been discussed on GitHub issue #544 as well as on the mailing list.  This change makes sense given the SC is simply about providing attributes to allow non-focused messages to be transformed into speech or braille.

Should close #544.