### PR TITLE
Introduction edits for CR

### DIFF
--- a/guidelines/guidelines.css
+++ b/guidelines/guidelines.css
@@ -6,24 +6,6 @@
 	display:inline;
 }
 
-.new {
-    border: medium solid #008000;
-}
-.proposed {
-    border: medium solid #D34245;
-}
-section.new, section.proposed {
-    padding: 1em;
-    margin-top: 1em;
-}
-dt.new, dt.proposed {
-    border-bottom: none;
-}
-dd.new, dd.proposed {
-    border-top: none;
-    margin-left: 0;
-    padding-left: 2em;
-}
 .doclinks {
 	float: right;
 	border: thin solid black;

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -23,51 +23,53 @@
             <p>To comment, <a href="https://github.com/w3c/wcag21/issues/new">file an issue in the <abbr title="World Wide Web Consortium">W3C</abbr> WCAG 2.1 GitHub repository</a>. Although the proposed Success Criteria in this document reference issues tracking discussion, the Working Group requests that public comments be filed as new issues, one issue per discrete comment. It is free to create a GitHub account to file issues. If filing issues in GitHub is not feasible, send email to <a href="mailto:public-agwg-comments@w3.org?subject=WCAG%202.1%20public%20comment">public-agwg-comments@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-agwg-comments/">comment archive</a>). </p>
         </section>
         <section class="informative introductory" id="intro">
-            <h2>Introduction</h2>
-
-            <section>
-                <h3>About This Draft</h3>
-				<p>Since the previous draft published in September, the Working Group has been working hard to review the final set of added success criteria in context of each other, and to address comments that have been submitted on drafts over the past year. This has resulted in changes to many of the success criteria to make them more implementable and backed by a stronger consensus. The Working Group expects these success criteria are in their final form, and plans to publish the Candidate Recommendation with these success criteria unless major concerns are raised by public review of this draft.</p>
-				<p class="note" id="further-work">Most success criteria in this draft are complete, but some are still under discussion. Those success criteria are marked with editorial notes with pointers to ongoing discussion. If you have an interest in the final form of the success criteria, we encourage you to track the discussion and check the <a href="https://w3c.github.io/wcag21/guidelines/">editors' draft</a> for changes, and submit comments quickly if you have concerns about changes underway. The Candidate Recommendation will include the final form of these success criteria, though they will be marked as "at risk" due to the lack of review opportunity from this current draft.</p>
-                <p>Because WCAG 2.1 extends WCAG 2.0, all the Success Criteria from WCAG 2.0 are included. To differentiate new Success Criteria, they are labeled as "[New]" and displayed in a <span class="new">green box</span>. To keep the guidelines clear for people who are familiar with WCAG 2.0, the WCAG 2.0 Success Criteria remain unchanged and have not been merged, moved, or renumbered to accommodate the new WCAG 2.1 Success Criteria. For this reason, WCAG 2.1 Success Criteria appear after the WCAG 2.0 Success Criteria in each guideline, which means that Success Criteria are no longer grouped by conformance level.</p>
-            </section>
-
-            <section>
-                <h3>Background on WCAG 2</h3>
-                <p>Web Content Accessibility Guidelines (WCAG) 2.1 defines how to make Web content more accessible to people with disabilities. Accessibility involves a wide range of disabilities, including visual, auditory, physical, speech, cognitive, language, learning, and neurological disabilities. Although these guidelines cover a wide range of issues, they are not able to address the needs of people with all types, degrees, and combinations of disability. These guidelines also make Web content more usable by older individuals with changing abilities due to aging and often improve usability for users in general.</p>
-                <p>WCAG 2.1 is developed through the <a href="https://www.w3.org/WAI/intro/w3c-process">W3C process</a> in cooperation with individuals and organizations around the world, with a goal of providing a shared standard for Web content accessibility that meets the needs of individuals, organizations, and governments internationally. WCAG 2.1 builds on WCAG 2.0 [[!WCAG20]], which in turn built on WCAG 1.0 [[WAI-WEBCONTENT]] and is designed to apply broadly to different Web technologies now and in the future, and to be testable with a combination of automated testing and human evaluation. For an introduction to WCAG, see the <a href="https://www.w3.org/WAI/intro/wcag">Web Content Accessibility Guidelines (WCAG) Overview</a>.</p>
-                <p>Web accessibility depends not only on accessible content but also on accessible Web browsers and other user agents. Authoring tools also have an important role in Web accessibility. For an overview of how these components of Web development and interaction work together, see:</p>
-                <ul>
-                    <li><strong><a href="https://www.w3.org/WAI/intro/components">Essential Components of Web Accessibility</a></strong></li>
-                    <li><strong><a href="https://www.w3.org/WAI/intro/uaag">User Agent Accessibility Guidelines (UAAG) Overview</a></strong></li>
-                    <li><strong><a href="https://www.w3.org/WAI/intro/atag">Authoring Tool Accessibility Guidelines (ATAG) Overview</a></strong></li>
-                </ul>
-                <p>Further introductory information about the structure of WCAG 2.0, inherited by WCAG 2.1, is available in the introduction to WCAG 2.0. For brevity in this draft it is not repeated here but can be found at:</p>
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG20/#intro-layers-guidance">WCAG 2.0 Layers of Guidance</a></li>
-                    <li><a href="https://www.w3.org/TR/WCAG20/#intro-related-docs">WCAG 2.0 Supporting Documents</a></li>
-                    <li><a href="https://www.w3.org/TR/WCAG20/#new-terms">Important Terms in WCAG 2.0</a></li>
-                </ul>
-            </section>
-
-            <section>
-                <h3>Conformance to WCAG 2.1</h3>
-                <p>WCAG 2.1 uses the same conformance model as WCAG 2.0 with a couple additions, which is described in the <a href="#conformance">Conformance</a> section. The conformance section has not been updated in this Working Draft to describe how WCAG 2.1 conformance builds upon WCAG 2.0 conformance. In particular, it is intended that sites that conform to WCAG 2.1 also conform to WCAG 2.0, which means they meet the requirements of any policies that reference WCAG 2.0, while also better meeting the needs of users on the current Web. </p>
-            </section>
-
-            <section>
-                <h3>Future work on WCAG 2.1</h3>
-                <p>The Accessibility Guidelines Working Group plans to continue developing WCAG 2.1 over the course of 2017. This work will primarily involve review and processing of the Success Criteria proposals, response to public feedback on this and later Working Drafts, and preparation of support materials similar to <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/">Understanding WCAG 2.0</a> [[UNDERSTANDING-WCAG20]] and <a href="https://www.w3.org/TR/WCAG20-TECHS/">Techniques for WCAG 2.0</a> [[WCAG20-TECHS]]. Early feedback on this work as soon as it is available is important, because the Working Group intends to begin finalization stages towards the end of the year.</p>
-                <p>Once the set of Success Criteria has been decided for WCAG 2.1, the Working Group will review the structure of the document. One goal will be to achieve the most clear backwards compatibility possible with WCAG 2.0; another will be to optimize the new Success Criteria to reduce duplication and increase clarity. The Working Group will also make final decisions about characteristics of the specification such as numbering and position of added Success Criteria. In preparation for the <a href="https://www.w3.org/2015/Process-20150901/#candidate-rec">Candidate Recommendation</a>, the Working Group will also re-evaluate testability and implementability of the Success Criteria given the technologies available at that time.</p>
-            </section>
-
-            <section>
-                <h3>Later versions of Accessibility Guidelines</h3>
-                <p>In parallel with WCAG 2.1, the Accessibility Guidelines Working Group is working on requirements for a 3.0 version of accessibility guidelines, developed by the <a href="https://www.w3.org/WAI/GL/task-forces/silver/">Silver Task Force</a>. The result of this work is expected to be a more substantial restructuring of web accessibility guidance than would be realistic for dot-releases of WCAG 2. The task force follows a research-focused, user-centered design methodology to produce the most effective and flexible outcome, including the roles of content authoring, user agent support, and authoring tool support. This is a multi-year effort, so WCAG 2.1 is needed as an interim measure to provide updated web accessibility guidance to reflect changes on the web since the publication of WCAG 2.0.</p>
-                <p>In order for WCAG 2.1 to achieve its goal to update web accessibility guidance in a time frame that is meaningful before the 3.0 project delivers results, WCAG 2.1 must be completed quickly. This inherently means that some proposed Success Criteria may prove too complex to include in WCAG 2.1, but nonetheless will be viewed as important accessibility guidance for current web content. The larger 3.0 project is expected to incorporate such guidance, but the Working Group could also decide that another set of guidelines between WCAG 2.1 and 3.0 is needed. In that case, a new version, WCAG 2.2, could be proposed. A decision to develop WCAG 2.2 will need to balance the benefits of providing additional accessibility guidance earlier, versus the opportunity cost the work could have on the more substantially restructured and comprehensive 3.0 project. The current <a href="https://www.w3.org/2017/01/ag-charter">Accessibility Guidelines Working Group charter</a> states "The Working Group intends to produce updated guidance for accessibility on a regular interval, starting with WCAG 2.1. Depending on the outcome of the requirements development for the next major update to WCAG, it may be necessary to pursue further dot-releases of WCAG until a major release is ready to be completed in time for a scheduled release date."</p>
-            </section>
-
-        </section>
+			<h2>Introduction</h2>
+			<section>
+				<h3>Background on WCAG 2</h3>
+				<p>Web Content Accessibility Guidelines (WCAG) 2.1 defines how to make Web content more accessible to people with disabilities. Accessibility involves a wide range of disabilities, including visual, auditory, physical, speech, cognitive, language, learning, and neurological disabilities. Although these guidelines cover a wide range of issues, they are not able to address the needs of people with all types, degrees, and combinations of disability. These guidelines also make Web content more usable by older individuals with changing abilities due to aging and often improve usability for users in general.</p>
+				<p>WCAG 2.1 is developed through the <a href="https://www.w3.org/WAI/intro/w3c-process">W3C process</a> in cooperation with individuals and organizations around the world, with a goal of providing a shared standard for Web content accessibility that meets the needs of individuals, organizations, and governments internationally. WCAG 2.1 builds on WCAG 2.0 [[!WCAG20]], which in turn built on WCAG 1.0 [[WAI-WEBCONTENT]] and is designed to apply broadly to different Web technologies now and in the future, and to be testable with a combination of automated testing and human evaluation. For an introduction to WCAG, see the <a href="https://www.w3.org/WAI/intro/wcag">Web Content Accessibility Guidelines (WCAG) Overview</a>.</p>
+				<p>Web accessibility depends not only on accessible content but also on accessible Web browsers and other user agents. Authoring tools also have an important role in Web accessibility. For an overview of how these components of Web development and interaction work together, see:</p>
+				<ul>
+					<li><strong><a href="https://www.w3.org/WAI/intro/components">Essential Components of Web Accessibility</a></strong></li>
+					<li><strong><a href="https://www.w3.org/WAI/intro/uaag">User Agent Accessibility Guidelines (UAAG) Overview</a></strong></li>
+					<li><strong><a href="https://www.w3.org/WAI/intro/atag">Authoring Tool Accessibility Guidelines (ATAG) Overview</a></strong></li>
+				</ul>
+				<p>Further introductory information about the structure of WCAG 2.0, inherited by WCAG 2.1, is available in the introduction to WCAG 2.0. For brevity in this draft it is not repeated here but can be found at:</p>
+				<ul>
+					<li><a href="https://www.w3.org/TR/WCAG20/#intro-layers-guidance">WCAG 2.0 Layers of Guidance</a></li>
+					<li><a href="https://www.w3.org/TR/WCAG20/#intro-related-docs">WCAG 2.0 Supporting Documents</a></li>
+					<li><a href="https://www.w3.org/TR/WCAG20/#new-terms">Important Terms in WCAG 2.0</a></li>
+				</ul>
+			</section>
+			<section>
+				<h3>New Features in WCAG 2.1</h3>
+				<p>WCAG 2.1 extends WCAG 2.0 by adding new success criteria, definitions to support them, guidelines to organize the additions, and a couple additions to the conformance section. This additive approach helps to make it clear that sites which conform to WCAG 2.1 also conform to WCAG 2.0, thereby meeting conformance obligations that are specific to WCAG 2.0. The Accessibility Guidelines Working Group recommends that sites adopt WCAG 2.1 as their new conformance target, even if formal obligations mention WCAG 2.0, to provide improved accessibility and to anticipate future policy changes.</p>
+				<p>The following Success Criteria are new in WCAG 2.1:</p>
+				<ul>
+					<li><a href="@@">@@Final list of SC</a></li>
+				</ul>
+				<p>Many of these success criteria reference new terms that have also been added to the glossary and form part of the normative requirements of the success criteria. </p>
+				<p>In the Conformance section, a third note about page variants has been added to <a href="#cc2">Full Pages</a>, and an option for machine-readable metadata added to <a href="#conformance-optional">Optional Components of a Conformance Claim</a>.</p>
+			</section>
+        	<section>
+        		<h3>Numbering in WCAG 2.1</h3>
+				<p>In order to avoid confusion for implementers for whom backwards compatibility to WCAG 2.0 is important, new success criteria in WCAG 2.1 have been appended to the end of the set of success criteria within their guideline. This avoids the need to change the section number of success criteria from WCAG 2.0, which would be caused by inserting new success critera between existing success ccriteria in the guideline, but it means success criteria in each guideline are no longer grouped by conformance level. The order of success criteria within each guideline does not imply information about conformance level; only the conformance level indicator (A / AA / AAA) on the success criterion itself indicates this. The <a href="https://www.w3.org/WAI/WCAG21/quickref/">WCAG 2.1 Quick Reference</a> provides ways to view success criteria grouped by conformance level, along with many other filter and sort options.</p>
+        	</section>
+			<section>
+				<h3>Conformance to WCAG 2.1</h3>
+				<p>WCAG 2.1 uses the same conformance model as WCAG 2.0 with a couple additions, which is described in the <a href="#conformance">Conformance</a> section. It is intended that sites that conform to WCAG 2.1 also conform to WCAG 2.0, which means they meet the requirements of any policies that reference WCAG 2.0, while also better meeting the needs of users on the current Web. </p>
+			</section>
+			<section>
+				<h3>Features at Risk in the WCAG 2.1 Candidate Recommdenation</h3>
+				<p>The <a href="#sotd">Status of This Document</a> section describes how implementation testing of WCAG 2.1 will be performed during the Candidate Recommendation period. In order to advance, the document must meet the exit criteria described. In addition, some features have been marked as "at risk". If a feature does not meet implementation targets by the end of the Candidate Recommendation period, it will be removed. Therefore, the final Web Content Accessibility Guidelines 2.1 could contain fewer requirements than this draft. Implementers are encouraged to pay extra attention to these features to help the Working Group gather implementation experience and avoid the need to remove such features.</p>
+			</section>
+			<section>
+				<h3>Later versions of Accessibility Guidelines</h3>
+				<p>In parallel with WCAG 2.1, the Accessibility Guidelines Working Group is working on requirements for a 3.0 version of accessibility guidelines, developed by the <a href="https://www.w3.org/WAI/GL/task-forces/silver/">Silver Task Force</a>. The result of this work is expected to be a more substantial restructuring of web accessibility guidance than would be realistic for dot-releases of WCAG 2. The task force follows a research-focused, user-centered design methodology to produce the most effective and flexible outcome, including the roles of content authoring, user agent support, and authoring tool support. This is a multi-year effort, so WCAG 2.1 is needed as an interim measure to provide updated web accessibility guidance to reflect changes on the web since the publication of WCAG 2.0.</p>
+				<p>In order for WCAG 2.1 to achieve its goal to update web accessibility guidance in a time frame that is meaningful before the 3.0 project delivers results, WCAG 2.1 must be completed quickly. This inherently means that some proposed Success Criteria may prove too complex to include in WCAG 2.1, but nonetheless will be viewed as important accessibility guidance for current web content. The larger 3.0 project is expected to incorporate such guidance, but the Working Group could also decide that another set of guidelines between WCAG 2.1 and 3.0 is needed. In that case, a new version, WCAG 2.2, could be proposed. A decision to develop WCAG 2.2 will need to balance the benefits of providing additional accessibility guidance earlier, versus the opportunity cost the work could have on the more substantially restructured and comprehensive 3.0 project. The current <a href="https://www.w3.org/2017/01/ag-charter">Accessibility Guidelines Working Group charter</a> states "The
+					Working Group intends to produce updated guidance for accessibility on a regular interval, starting with WCAG 2.1. Depending on the outcome of the requirements development for the next major update to WCAG, it may be necessary to pursue further dot-releases of WCAG until a major release is ready to be completed in time for a scheduled release date."</p>
+			</section>
+		</section>
         <section class="principle" id="perceivable">
             <h2> Perceivable </h2>
             <p>Information and user interface components must be presentable to users in ways they can perceive.</p>

--- a/script/wcag21.js
+++ b/script/wcag21.js
@@ -16,10 +16,9 @@ function linkUnderstanding() {
 }
 
 function addTextSemantics() {
-	// put brackets around the change marker
+	// remove the change marker
 	document.querySelectorAll('p.change').forEach(function(node){
-		var change = node.textContent;
-		node.textContent = "[" + change + "]";
+		node.parentNode.removeChild(node);
 	})
 	// put level before and parentheses around the conformance level marker
 	document.querySelectorAll('p.conformance-level').forEach(function(node){


### PR DESCRIPTION
Entering Candidate Recommendation, the introduction should speak less about draft review and more about new features. As a non-normative section these edits are editorial, but the WG should probably review and suggest tweaks so they're not a surprise.