### PR TITLE
Edits to Content on Hover or Focus

### DIFF
--- a/guidelines/sc/21/content-on-hover-or-focus.html
+++ b/guidelines/sc/21/content-on-hover-or-focus.html
@@ -11,7 +11,7 @@
   <dl>
 
     <dt>Dismissable</dt>
-    <dd>A <a>mechanism</a> is available to dismiss the additional content without moving pointer hover or keyboard focus, unless the additional content communicates an <a>input error</a>;</dd>
+    <dd>A <a>mechanism</a> is available to dismiss the additional content without moving pointer hover or keyboard focus, unless the additional content communicates an <a>input error</a> or does not obscure or replace other content;</dd>
 
     <dt>Hoverable</dt>
    <dd>If pointer hover can trigger the additional content, then the pointer can be moved  over the additional content without the additional content disappearing;</dd>

--- a/guidelines/sc/21/content-on-hover-or-focus.html
+++ b/guidelines/sc/21/content-on-hover-or-focus.html
@@ -6,7 +6,7 @@
        
    <p class="change">New</p>
    					
-    	<p>When pointer hover or keyboard focus triggers additional content to become visible, the following are true:</p>
+    	<p>Where the receipt and removal of pointer hover or keyboard focus triggers additional content to become visible and hidden, respectively, the following are true:</p>
 
   <dl>
 

--- a/guidelines/sc/21/content-on-hover-or-focus.html
+++ b/guidelines/sc/21/content-on-hover-or-focus.html
@@ -6,7 +6,7 @@
        
    <p class="change">New</p>
    					
-    	<p>Where the receipt and removal of pointer hover or keyboard focus triggers additional content to become visible and hidden, respectively, the following are true:</p>
+    	<p>Where receiving and removing pointer hover or keyboard focus triggers additional content to become visible and hidden, respectively, the following are true:</p>
 
   <dl>
 

--- a/guidelines/sc/21/content-on-hover-or-focus.html
+++ b/guidelines/sc/21/content-on-hover-or-focus.html
@@ -14,7 +14,7 @@
     <dd>A <a>mechanism</a> is available to dismiss the additional content without moving pointer hover or keyboard focus, unless the additional content communicates an <a>input error</a>;</dd>
 
     <dt>Hoverable</dt>
-   <dd>If pointer hover can trigger the additional content, then the pointer can be moved to hover over the additional content;</dd>
+   <dd>If pointer hover can trigger the additional content, then the pointer can be moved  over the additional content without the additional content disappearing;</dd>
 
     <dt>Persistent</dt>
     <dd>The additional content remains visible until the hover or focus trigger is removed, the user dismisses it, or its information is no longer valid.</dd>

--- a/guidelines/sc/21/content-on-hover-or-focus.html
+++ b/guidelines/sc/21/content-on-hover-or-focus.html
@@ -14,7 +14,7 @@
     <dd>A <a>mechanism</a> is available to dismiss the additional content without moving pointer hover or keyboard focus, unless the additional content communicates an <a>input error</a>;</dd>
 
     <dt>Hoverable</dt>
-   <dd>If pointer hover can trigger the additional content, then the pointer can be moved to hover the additional content;</dd>
+   <dd>If pointer hover can trigger the additional content, then the pointer can be moved to hover over the additional content;</dd>
 
     <dt>Persistent</dt>
     <dd>The additional content remains visible until the hover or focus trigger is removed, the user dismisses it, or its information is no longer valid.</dd>


### PR DESCRIPTION
Changes for this pull request can be viewed at: http://rawgit.com/w3c/wcag21/hover-focus-edits/guidelines/#content-on-hover-or-focus

The following changes are made:
1. Revision to Hoverable condition to use more plain language (issues #695 and #711)
2. Revised initial sentence to scope to additional content which also disappears on hover or focus.  This is needed to scope out content that may appear on focus such as in a tab list, drop down box, etc. (issue #650)
3. Adds an exception to the Dismissable condition when the additional content doesn't obscure or replace anything.  This addresses comments on mailing list regarding things like help content inserted inline when an input field has focus.


