### PR TITLE
Editorial link additions

### DIFF
--- a/guidelines/sc/21/identify-common-purpose.html
+++ b/guidelines/sc/21/identify-common-purpose.html
@@ -6,10 +6,10 @@
 	
 	<p class="change">New</p>
 	
-	<p>The meaning of each input field collecting information about the user can be programmatically determined when:</p>
+	<p>The meaning of each input field collecting information about the user can be <a>programmatically determined</a> when:</p>
   
   <ul>
-    <li>The input field has a meaning that maps to the HTML <a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">5.2 Autofill field names</a>; and</li>
+    <li>The input field has a meaning that maps to the <a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">HTML 5.2 Autofill field names</a>; and</li>
     <li>The content is implemented using technologies with support for identifying the expected meaning for form input data.</li>
   </ul>
   

--- a/guidelines/sc/21/identify-purpose.html
+++ b/guidelines/sc/21/identify-purpose.html
@@ -6,5 +6,5 @@
    					
    <p class="change">New</p>
 	   					
-  <p>In content implemented using markup languages, the purpose of <a>User Interface Components</a>, icons, and <a>regions</a> can be programmatically determined.</p>
+  <p>In content implemented using markup languages, the purpose of <a>User Interface Components</a>, icons, and <a>regions</a> can be <a>programmatically determined</a>.</p>
 </section>


### PR DESCRIPTION
This makes 2 simple editorial changes:
1. Added links to pro grammatically determined to both Identify Purpose and Identify Common Purpose.
2. Included "HTML" in the anchor linking to the HTML 5.2 autofill names
