### PR TITLE
Deleted repeated sentence

### DIFF
--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -51,7 +51,7 @@
 
 				<p>For active controls on the page, such as buttons and form fields, the visual boundaries of the component must have sufficient contrast with the adjacent background. Also, the visual effects which indicate state, such as whether a component is selected or focused, must also provide the minimum 3:1 contrast with the adjacent background of the component.</p>
 				<p>This success criteria does not require that controls have a visual indicator, but that if there is an indicator, it has sufficient contrast.</p>
-        <p>Regardless of the whether or not there is a visible indication of the hit area for the button, the focus indicator for the component must have sufficient contrast when the component is focused. If only the text (or icon) is visible and there is no visual indication of the hit area, then there is no contrast requirement beyond the text contrast (as per 1.4.3) or icon contrast as per this Success Criteria. Regardless of the whether or not there is a visible indication of the hit area for the button, the focus indicator for the component must have sufficient contrast when the component is focused.</p>
+        <p>If only the text (or icon) is visible and there is no visual indication of the hit area, then there is no contrast requirement beyond the text contrast (as per 1.4.3) or icon contrast as per this Success Criteria. Regardless of the whether or not there is a visible indication of the hit area for the button, the focus indicator for the component must have sufficient contrast when the component is focused.</p>
         
 
 				<section id="ref-1-4-1">


### PR DESCRIPTION
This sentence was repeated "Regardless of the whether or not there is a visible indication of the hit area for the button, the focus indicator for the component must have sufficient contrast when the component is focused. "