### PR TITLE
Add period at the end of the guideline text

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -286,7 +286,7 @@
             <section class="guideline new">
                 <h3>Input Modalities</h3>
                 <p class="change">New</p>
-                <p>Make it easier for users to operate functionality through various inputs beyond keyboard</p>
+                <p>Make it easier for users to operate functionality through various inputs beyond keyboard.</p>
 
                 <section data-include="sc/21/pointer-gestures.html" data-include-replace="true"></section>
 


### PR DESCRIPTION
Other guidelines have a period there, too.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag21/pull/919.html" title="Last updated on May 14, 2018, 2:18 AM GMT (d72d5d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag21/919/3de5eaf...d72d5d9.html" title="Last updated on May 14, 2018, 2:18 AM GMT (d72d5d9)">Diff</a>