### PR TITLE
removed failure with text preceding label

### DIFF
--- a/understanding/21/label-in-name.html
+++ b/understanding/21/label-in-name.html
@@ -50,7 +50,7 @@
 			
 			<section id="sufficient">
 				<h3>Sufficient</h3>
-				<ul><li>Ensure that visible labels match their accessible names</li></ul>
+				<ul><li>Ensuring that visible labels match their accessible names</li></ul>
 			</section>
 			<section id="advisory">
 				<h2>Advisory</h2>

--- a/understanding/21/label-in-name.html
+++ b/understanding/21/label-in-name.html
@@ -62,7 +62,6 @@
           <li>Accessible name does not contain the visible label text</li>
           <li>Accessible name contains the visible label text, but the words of the visible label are not in the same order as they are in the visible label text</li>
           <li>Accessible name contains the visible label text, but one or more other words is interspersed in the label</li>
-          <li>Accessible name contains the visible label text, but one or more other words comes before the visible label text</li>
         </ul>
 			</section>
 		</section>


### PR DESCRIPTION
As Glenda has commented, this failure actually isn't one - while it is not practice to start the accessible name with the label text, it should not be a failure if this text is preceded by other text but the label text string fully matches some part in the accessible name.